### PR TITLE
clean: remove the verbosity in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -eo pipefail
-set -x
+#set -x
 
 # Installs the bazel_local_nix tools into the current bazel repository.
 


### PR DESCRIPTION
Should no longer be needed, as the install script seems to pass as expected.