### PR TITLE
Jules PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,22 +14,34 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: 7.2.0
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: 'true'
+
+      - name: Setup bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 7.2.0
+
+      - name: Cache Bazel
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-${{ hashFiles('MODULE.bazel') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-
+
       - name: Build
         run: "bazel build //..."
+
       - name: Test With Nix Clang
         run: |
           cd integration/with-nix-clang \
           && bazel --max_idle_secs=20 run @bazel_local_nix//:install \
           && bazel --max_idle_secs=20 shutdown \
           && bazel --max_idle_secs=20 run --config=nix //:hello
+
       - name: Test With Partially installed nix
         run: |
           cd integration/partially-installed \


### PR DESCRIPTION
ci: Add caching for Bazel artifacts

This change introduces caching for Bazel download and build artifacts
in the GitHub Actions workflow. It uses actions/cache@v3 to store
the Bazel cache (~/.cache/bazel) and keys the cache on the runner's OS
and the hash of the MODULE.bazel file.

This should help speed up build times by reusing previously downloaded
dependencies and built artifacts across workflow runs.

---
*PR created automatically by Jules for task [14316282406419313234](https://jules.google.com/task/14316282406419313234) started by @filmil*