### PR TITLE
chore: remove obsolete .bcr/source.json

### DIFF
--- a/.bcr/source.json
+++ b/.bcr/source.json
@@ -1,4 +1,0 @@
-{
-    "url": "https://github.com/filmil/bazel_local_nix/archive/refs/tags/v0.0.1.tar.gz",
-    "strip_prefix": "bazel_local_nix-0.0.1"
-}


### PR DESCRIPTION
Now that `.bcr/source.template.json` is used for release configuration, the static `source.json` is obsolete and can be safely removed.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt used to generate the pull request:
send PR for the current changes