### PR TITLE
chore: remove debugging fixtures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,25 +35,6 @@ jobs:
       - name: Test
         run: "bazel test --verbose_failures --test_output=errors //..."
       - name: Build integration (partially-installed)
-        run: |
-          set -x
-          cd integration/partially-installed
-          bazel build --verbose_failures --ui_event_filters=info,debug,error,warning --experimental_ui_max_stdouterr_bytes=-1 --experimental_repository_cache_hardlinks //...
-      - name: System Diagnostics
-        run: |
-          bwrap --version || echo "bwrap not found"
-          ls -l /usr/bin/bwrap || echo "/usr/bin/bwrap not found"
-          cat /proc/sys/kernel/unprivileged_userns_clone || echo "unprivileged_userns_clone not found"
-          sysctl kernel.unprivileged_userns_clone || true
-          id
-          env
-          df -h
-          mount | grep /nix || true
-          bwrap --unshare-user --uid 0 true && echo "bwrap works" || echo "bwrap failed"
-          ls -R integration
+        run: "cd integration/partially-installed && bazel build --verbose_failures //..."
       - name: Build integration (with-nix-clang)
-        run: |
-          set -x
-          cd integration/with-nix-clang
-          bazel build --verbose_failures --ui_event_filters=info,debug,error,warning --experimental_ui_max_stdouterr_bytes=-1 --toolchain_resolution_debug=.* //:hello
-          bazel build --verbose_failures --ui_event_filters=info,debug,error,warning --experimental_ui_max_stdouterr_bytes=-1 //...
+        run: "cd integration/with-nix-clang && bazel build --verbose_failures //..."

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -18,7 +18,6 @@ load("//:nix_cc.bzl", "nix_cc_repo")
 _DEFAULT_NIXPKGS = "github:NixOS/nixpkgs/b134951a4c9f3c995fd7be05f3243f8ecd65d798"
 
 def _nix_cc_impl(module_ctx):
-    print("DEBUG: entering _nix_cc_impl")
     for mod in module_ctx.modules:
         for cfg in mod.tags.configure:
             nix_cc_repo(

--- a/integration/with-nix-clang/MODULE.bazel.lock
+++ b/integration/with-nix-clang/MODULE.bazel.lock
@@ -562,7 +562,7 @@
     },
     "@@rules_nix+//:extensions.bzl%nix_cc": {
       "general": {
-        "bzlTransitiveDigest": "4k7a/dYNyaEHy6uEvJ664gAkg/dlZDsRzirRNB8TIRo=",
+        "bzlTransitiveDigest": "e0Bmtt6oGPrM2skS1RUC0rFyExxOGhAE5U7492Va/uE=",
         "usagesDigest": "h8zFony4cxrJ9o/39Ej2I8klQzt9d9E/UsDtJBSjlnA=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_tools,rules_cc rules_cc+",
@@ -571,6 +571,7 @@
           "REPO_MAPPING:rules_cc+,platforms platforms",
           "REPO_MAPPING:rules_cc++compatibility_proxy+cc_compatibility_proxy,rules_cc rules_cc+",
           "REPO_MAPPING:rules_nix+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_nix+,nix_bootstrap rules_nix++nix_bootstrap+nix_bootstrap",
           "REPO_MAPPING:rules_nix+,rules_cc rules_cc+"
         ],
         "generatedRepoSpecs": {

--- a/nix_bootstrap.bzl
+++ b/nix_bootstrap.bzl
@@ -22,7 +22,6 @@ filegroup(
 """
 
 def _nix_bootstrap_impl(repository_ctx):
-    print("DEBUG: entering _nix_bootstrap_impl")
     nix_url = "https://releases.nixos.org/nix/nix-{v}/nix-{v}-x86_64-linux.tar.xz".format(
         v = NIX_VERSION,
     )
@@ -34,9 +33,6 @@ def _nix_bootstrap_impl(repository_ctx):
 
     res = repository_ctx.execute(["tar", "xf", "nix.tar.xz"])
     if res.return_code != 0:
-        print("nix_bootstrap: tar xf failed")
-        print("stdout: " + res.stdout)
-        print("stderr: " + res.stderr)
         fail("nix_bootstrap: tar xf failed:\n" + res.stderr)
     repository_ctx.execute(["rm", "nix.tar.xz"])
 

--- a/nix_cc.bzl
+++ b/nix_cc.bzl
@@ -151,7 +151,6 @@ def _find_store_bin(repository_ctx, pattern):
     return None
 
 def _nix_cc_repo_impl(repository_ctx):
-    print("DEBUG: entering _nix_cc_repo_impl for " + repository_ctx.name)
     wrapper = repository_ctx.path(repository_ctx.attr._nix_wrapper)
     installable = repository_ctx.attr.installable
 
@@ -164,9 +163,6 @@ def _nix_cc_repo_impl(repository_ctx):
         quiet = False,
     )
     if build.return_code != 0:
-        print("nix_cc: build failed")
-        print("stdout: " + build.stdout)
-        print("stderr: " + build.stderr)
         fail("nix_cc: failed to build {}:\n{}".format(installable, build.stderr))
     lines = [l for l in build.stdout.splitlines() if l]
     if not lines:
@@ -182,9 +178,6 @@ def _nix_cc_repo_impl(repository_ctx):
         timeout = 1200,
     )
     if info.return_code != 0:
-        print("nix_cc: path-info failed")
-        print("stdout: " + info.stdout)
-        print("stderr: " + info.stderr)
         fail("nix_cc: failed to query closure:\n" + info.stderr)
     closure = [p for p in info.stdout.splitlines() if p]
 

--- a/nix_rules.bzl
+++ b/nix_rules.bzl
@@ -12,7 +12,6 @@ _DEFAULT_NIXPKGS = "github:NixOS/nixpkgs/b134951a4c9f3c995fd7be05f3243f8ecd65d79
 _DEFAULT_INSTALLABLE = _DEFAULT_NIXPKGS + "#hello"
 
 def _nix_package_impl(ctx):
-    print("DEBUG: entering _nix_package_impl for " + ctx.label.name)
     output_tarball = ctx.actions.declare_file(ctx.label.name + ".tar.gz")
     nix_wrapper = ctx.executable._nix_wrapper
     shim = ctx.file._run_shim


### PR DESCRIPTION
This PR cleans up the debugging fixtures and diagnostic output added during the CI investigation.

Key changes:
- Removed `DEBUG` print statements from `nix_rules.bzl`, `nix_bootstrap.bzl`, `nix_cc.bzl`, and `extensions.bzl`.
- Cleaned up `.github/workflows/test.yml` by removing diagnostic steps (env dump, system diagnostics, etc.) and excessive Bazel UI flags.
- Retained the essential fix for AppArmor user namespace restrictions on Ubuntu 24.04.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt used to generate the pull request:
this worked. in a separate PR, remove any debugging-only fixtures