### PR TITLE
feat: bundle hermetic static bwrap instead of host-provided one

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,8 @@ exports_files([
     "nix_wrapper.sh.tpl",
     "nix_run_shim.sh",
     "nix_cc_wrapper.sh.tpl",
+    "nix_package_build.sh.tpl",
+    "nix_extract.sh.tpl",
 ])
 
 # Gazelle for Starlark
@@ -86,6 +88,8 @@ genrule(
     srcs = [
         "@nix_bootstrap//:nix_binaries",
         "@nix_bootstrap//:nix_wrapper.sh",
+        # The wrapper execs the bundled static bwrap from its own dir.
+        "@nix_bootstrap//:bwrap",
     ],
     outs = ["nix_version.txt"],
     cmd = "$(location @nix_bootstrap//:nix_wrapper.sh) --version > $@ 2>&1 || true",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Bazel rules that make Nix packages available inside a Bazel workspace
 **without a host-level Nix installation and without `nix-portable`**. They
 bootstrap an ephemeral Nix from the official binary release, run it
 unprivileged inside a `bwrap` (bubblewrap) user namespace against a persistent
-store, and expose the results as ordinary Bazel artifacts.
+store, and expose the results as ordinary Bazel artifacts. The `bwrap` binary
+itself is fetched as a pinned, statically-linked release during bootstrap, so
+**no host-provided `bwrap` is required** — only permission to create
+unprivileged user namespaces.
 
 > **Note on history.** Earlier versions of this repository shimmed *all* of
 > Bazel through a `nix-portable` `nix-shell` via an injected `tools/bazel`
@@ -16,8 +19,9 @@ store, and expose the results as ordinary Bazel artifacts.
 ## Requirements
 
 - Linux `x86_64`.
-- `bwrap` (bubblewrap) on `PATH` and permission to create **unprivileged user
-  namespaces**.
+- Permission to create **unprivileged user namespaces** (`bwrap` itself is
+  bundled — fetched as a pinned static binary during bootstrap — so it does not
+  need to be installed on the host).
 - `bash`, `tar`, `xz`, `cp`, `flock`, and coreutils.
 - Network egress to `https://releases.nixos.org` (bootstrap) and
   `https://cache.nixos.org` (substitutes).
@@ -102,8 +106,10 @@ The produced binaries link against `/nix/store`, so they run on a host with no
 ## How it works
 
 - **`nix_bootstrap`** (repository rule) downloads a pinned, checksummed Nix
-  release, unpacks it, and materializes the runtime wrapper `nix_wrapper.sh`
-  and the relocatable run-shim from `nix_wrapper.sh.tpl` / `nix_run_shim.sh`.
+  release plus a pinned, statically-linked `bwrap` binary, unpacks them, and
+  materializes the runtime wrapper `nix_wrapper.sh` and the relocatable run-shim
+  from `nix_wrapper.sh.tpl` / `nix_run_shim.sh`. Every wrapper and shim execs
+  the bundled `bwrap`, never a host one.
 - **`nix_wrapper.sh`** runs an arbitrary `nix` subcommand inside `bwrap`
   against a persistent, single-user store under
   `<output_user_root>/rules_nix_store` (override with `RULES_NIX_CACHE`). The

--- a/docs/nix_bootstrap.md
+++ b/docs/nix_bootstrap.md
@@ -14,8 +14,11 @@ nix_bootstrap(<a href="#nix_bootstrap-name">name</a>)
 
 Repository rule that fetches a pinned Nix binary release.
 
-Unpacks the official Nix binary release and materializes the bwrap
-wrapper script ('nix_wrapper.sh') required by nix_package.
+Unpacks the official Nix binary release, fetches a pinned statically-linked
+bwrap (bubblewrap) binary, and materializes the bwrap wrapper script
+('nix_wrapper.sh') required by nix_package. Bundling bwrap removes the need
+for a host-provided bwrap; the only remaining host requirement is permission
+to create unprivileged user namespaces.
 
 **ATTRIBUTES**
 

--- a/docs/nix_rules.md
+++ b/docs/nix_rules.md
@@ -16,8 +16,8 @@ Builds a Nix installable into a self-contained, relocatable <name>.tar.gz bundle
 
 The produced bundle contains the full runtime closure of the installable,
 with absolute /nix/store paths preserved. It also includes relocatable
-bin/ shims that allow running the bundled binaries on hosts without
-a local /nix/store.
+bin/ shims and a bundled static bwrap that allow running the bundled
+binaries on hosts without a local /nix/store or a host-provided bwrap.
 
 **ATTRIBUTES**
 

--- a/nix_bootstrap.bzl
+++ b/nix_bootstrap.bzl
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # nix_bootstrap.bzl
 #
-# Repository rule that fetches a pinned, relocatable Nix binary release and
-# materializes the bwrap runtime wrapper. This is the Nix analog of
-# rules_guix's guix_bootstrap rule; unlike Guix it does not rely on a
-# system daemon -- single-user Nix operates on the store directly.
+# Repository rule that fetches a pinned, relocatable Nix binary release and a
+# pinned, statically-linked bwrap binary, then materializes the bwrap runtime
+# wrapper. This is the Nix analog of rules_guix's guix_bootstrap rule; unlike
+# Guix it does not rely on a system daemon -- single-user Nix operates on the
+# store directly.
 
 # Pinned Nix release. Bumping these two values (and re-running) is the only
 # change required to track a new Nix; the wrapper discovers binaries in a
@@ -12,8 +13,24 @@
 NIX_VERSION = "2.24.10"
 NIX_SHA256 = "ec1023e4c0e01da4bbec64c19e9a2bc94d36feae421402abbf3a2db848a1c6b5"
 
+# Pinned, statically-linked bwrap (bubblewrap) binary. bwrap is needed to *run*
+# the bootstrap Nix (it binds the bundled store at /nix/store), so it cannot
+# itself come from Nix -- it must be a standalone binary independent of
+# /nix/store. We fetch a musl-static build so the sandbox no longer depends on
+# a host-provided bwrap; the only remaining host requirement is permission to
+# create unprivileged user namespaces. Bumping these tracks a new bwrap.
+BWRAP_VERSION = "0.11.0"
+BWRAP_URL = "https://github.com/VHSgunzo/bubblewrap-static/releases/download/v0.11.0.2/bwrap-x86_64"
+BWRAP_SHA256 = "019dcf296d5f84f000b35db4f005900fa44ddead2723f932d63c022d24992ed7"
+
 _BOOTSTRAP_BUILD = """
-exports_files(["nix_wrapper.sh", "nix_run_shim.sh"])
+# bwrap is the statically-linked bubblewrap binary that every wrapper/shim
+# execs; it is exported so nix_package and nix_cc can copy it into their
+# bundles for relocatable use, and is publicly visible like the rest.
+exports_files(
+    ["nix_wrapper.sh", "nix_run_shim.sh", "bwrap"],
+    visibility = ["//visibility:public"],
+)
 filegroup(
     name = "nix_binaries",
     srcs = glob(["nix-*-x86_64-linux/**"]),
@@ -36,6 +53,17 @@ def _nix_bootstrap_impl(repository_ctx):
         fail("nix_bootstrap: tar xf failed:\n" + res.stderr)
     repository_ctx.execute(["rm", "nix.tar.xz"])
 
+    # Fetch the pinned static bwrap and make it executable. This is the
+    # hermetic replacement for a host-provided bwrap: every wrapper and shim
+    # execs this binary (discovered relative to its own location) instead of
+    # resolving `bwrap` from PATH.
+    repository_ctx.download(
+        url = BWRAP_URL,
+        output = "bwrap",
+        sha256 = BWRAP_SHA256,
+        executable = True,
+    )
+
     # The wrapper and run-shim are maintained as real shell files (so they stay
     # lintable and free of escaping); we just copy them into place. They live
     # in the bootstrap repo -- not the rules_nix root package -- so that
@@ -57,8 +85,11 @@ nix_bootstrap = repository_rule(
     implementation = _nix_bootstrap_impl,
     doc = """Repository rule that fetches a pinned Nix binary release.
 
-Unpacks the official Nix binary release and materializes the bwrap
-wrapper script ('nix_wrapper.sh') required by nix_package.
+Unpacks the official Nix binary release, fetches a pinned statically-linked
+bwrap (bubblewrap) binary, and materializes the bwrap wrapper script
+('nix_wrapper.sh') required by nix_package. Bundling bwrap removes the need
+for a host-provided bwrap; the only remaining host requirement is permission
+to create unprivileged user namespaces.
 """,
     attrs = {
         "_wrapper": attr.label(

--- a/nix_cc.bzl
+++ b/nix_cc.bzl
@@ -212,6 +212,15 @@ def _nix_cc_repo_impl(repository_ctx):
             executable = True,
         )
 
+    # Copy the pinned static bwrap to the repo root so each tool wrapper can
+    # exec it as "$HERE/bwrap" instead of relying on a host-provided bwrap.
+    cp_bwrap = repository_ctx.execute(
+        ["cp", str(repository_ctx.path(repository_ctx.attr._bwrap)), "bwrap"],
+    )
+    if cp_bwrap.return_code != 0:
+        fail("nix_cc: failed to copy bwrap:\n" + cp_bwrap.stderr)
+    repository_ctx.execute(["chmod", "+x", "bwrap"])
+
     repository_ctx.file("BUILD.bazel", content = _GENERATED_BUILD)
 
 nix_cc_repo = repository_rule(
@@ -233,6 +242,11 @@ the external repository, and generates a cc_toolchain definition.
         "_wrapper": attr.label(
             doc = "Template for individual tool wrappers (e.g. gcc, ld).",
             default = Label("//:nix_cc_wrapper.sh.tpl"),
+            allow_single_file = True,
+        ),
+        "_bwrap": attr.label(
+            doc = "Statically-linked bwrap binary from bootstrap.",
+            default = Label("@nix_bootstrap//:bwrap"),
             allow_single_file = True,
         ),
     },

--- a/nix_cc_wrapper.sh.tpl
+++ b/nix_cc_wrapper.sh.tpl
@@ -45,4 +45,7 @@ binds+=(
     --setenv PATH "%{GUEST_PATH}%"
 )
 
-exec bwrap "${binds[@]}" /usr/bin/env "$TOOL" "$@"
+# Use the pinned static bwrap copied into this toolchain repo by nix_cc_repo,
+# not a host-provided one (hermeticity). It sits at the repo root next to the
+# nix/store tree.
+exec "$HERE/bwrap" "${binds[@]}" /usr/bin/env "$TOOL" "$@"

--- a/nix_extract.sh.tpl
+++ b/nix_extract.sh.tpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Extract script for the nix_toolchain rule, materialized per target by
+# expand_template (placeholders %{...}%): unpacks a nix_package bundle into a
+# directory tree that downstream rules can read.
+set -euo pipefail
+OUT_DIR="%{OUT_DIR}%"
+BUNDLE="%{BUNDLE}%"
+
+mkdir -p "$OUT_DIR"
+tar -xzf "$BUNDLE" -C "$OUT_DIR"

--- a/nix_package_build.sh.tpl
+++ b/nix_package_build.sh.tpl
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build script for the nix_package rule, materialized per target by
+# expand_template (placeholders %{...}%). Realizes the installable from the
+# binary cache, gathers its runtime closure, and tars it (plus relocatable bin/
+# shims and a bundled static bwrap) into the output. The wrapper rewrites the
+# guest /nix/store paths it prints to host locations under the persistent
+# CACHE_BASE, so STORE_OUT/CLOSURE are readable here.
+set -euo pipefail
+WRAPPER="%{WRAPPER}%"
+INSTALLABLE="%{INSTALLABLE}%"
+OUT="%{OUT}%"
+SHIM="%{SHIM}%"
+BWRAP="%{BWRAP}%"
+
+STORE_OUT=$("$WRAPPER" build --no-link --print-out-paths "$INSTALLABLE" | tail -n 1)
+if [ -z "$STORE_OUT" ] || [ ! -e "$STORE_OUT" ]; then
+    echo "nix_package: failed to realize $INSTALLABLE (got: '$STORE_OUT')" >&2
+    exit 1
+fi
+GUEST_OUT="/nix/store/$(basename "$STORE_OUT")"
+CLOSURE=$("$WRAPPER" path-info -r "$INSTALLABLE")
+
+WORK=$(mktemp -d)
+mkdir -p "$WORK/bin" "$WORK/nix/store"
+printf '%s\n' "$GUEST_OUT" > "$WORK/.nix_out"
+
+# Ship the static bwrap at the bundle root so the run-shim can exec it
+# ("$HERE/bwrap") on a host with no bwrap of its own.
+cp "$BWRAP" "$WORK/bwrap"
+chmod +x "$WORK/bwrap"
+
+if [ -d "$STORE_OUT/bin" ]; then
+    for exe in "$STORE_OUT/bin/"*; do
+        [ -e "$exe" ] || continue
+        cp "$SHIM" "$WORK/bin/$(basename "$exe")"
+        chmod +x "$WORK/bin/$(basename "$exe")"
+    done
+fi
+
+for p in $CLOSURE; do
+    [ -e "$p" ] || continue
+    cp -a "$p" "$WORK/nix/store/"
+done
+chmod -R u+w "$WORK/nix/store" 2>/dev/null || true
+
+tar czf "$OUT" -C "$WORK" .
+rm -rf "$WORK"

--- a/nix_rules.bzl
+++ b/nix_rules.bzl
@@ -15,58 +15,34 @@ def _nix_package_impl(ctx):
     output_tarball = ctx.actions.declare_file(ctx.label.name + ".tar.gz")
     nix_wrapper = ctx.executable._nix_wrapper
     shim = ctx.file._run_shim
+    bwrap = ctx.file._bwrap
 
-    # Realize the installable from the binary cache, gather its runtime
-    # closure, and tar it (plus relocatable bin/ shims) into the output. The
-    # wrapper rewrites the guest /nix/store paths it prints to host locations
-    # under the persistent CACHE_BASE, so STORE_OUT/CLOSURE are readable here.
-    script = """
-set -euo pipefail
-WRAPPER="{wrapper}"
-INSTALLABLE="{installable}"
-OUT="{out}"
-SHIM="{shim}"
-
-STORE_OUT=$("$WRAPPER" build --no-link --print-out-paths "$INSTALLABLE" | tail -n 1)
-if [ -z "$STORE_OUT" ] || [ ! -e "$STORE_OUT" ]; then
-    echo "nix_package: failed to realize $INSTALLABLE (got: '$STORE_OUT')" >&2
-    exit 1
-fi
-GUEST_OUT="/nix/store/$(basename "$STORE_OUT")"
-CLOSURE=$("$WRAPPER" path-info -r "$INSTALLABLE")
-
-WORK=$(mktemp -d)
-mkdir -p "$WORK/bin" "$WORK/nix/store"
-printf '%s\\n' "$GUEST_OUT" > "$WORK/.nix_out"
-
-if [ -d "$STORE_OUT/bin" ]; then
-    for exe in "$STORE_OUT/bin/"*; do
-        [ -e "$exe" ] || continue
-        cp "$SHIM" "$WORK/bin/$(basename "$exe")"
-        chmod +x "$WORK/bin/$(basename "$exe")"
-    done
-fi
-
-for p in $CLOSURE; do
-    [ -e "$p" ] || continue
-    cp -a "$p" "$WORK/nix/store/"
-done
-chmod -R u+w "$WORK/nix/store" 2>/dev/null || true
-
-tar czf "$OUT" -C "$WORK" .
-rm -rf "$WORK"
-""".format(
-        wrapper = nix_wrapper.path,
-        installable = ctx.attr.installable,
-        out = output_tarball.path,
-        shim = shim.path,
+    # Realize the installable and tar its closure (plus relocatable bin/ shims
+    # and a bundled static bwrap) into the output. The build steps live in
+    # nix_package_build.sh.tpl -- kept as a real shell file so it stays lintable
+    # and free of escaping -- and are materialized per target by expand_template.
+    build_script = ctx.actions.declare_file(ctx.label.name + "_build.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._build_tpl,
+        output = build_script,
+        is_executable = True,
+        substitutions = {
+            "%{WRAPPER}%": nix_wrapper.path,
+            "%{INSTALLABLE}%": ctx.attr.installable,
+            "%{OUT}%": output_tarball.path,
+            "%{SHIM}%": shim.path,
+            "%{BWRAP}%": bwrap.path,
+        },
     )
 
     ctx.actions.run_shell(
         outputs = [output_tarball],
-        inputs = ctx.files._nix_binaries + [shim],
+        # bwrap is both copied into the bundle and required at $REPO_ROOT/bwrap
+        # by the wrapper that runs nix; listing it as an input stages it next to
+        # the wrapper in the bootstrap repo.
+        inputs = ctx.files._nix_binaries + [shim, bwrap, build_script],
         tools = [nix_wrapper],
-        command = script,
+        command = build_script.path,
         mnemonic = "NixPackage",
         progress_message = "Building Nix package %s" % ctx.attr.installable,
         # nix build reads/writes a persistent store that survives across builds
@@ -89,8 +65,8 @@ nix_package = rule(
 
 The produced bundle contains the full runtime closure of the installable,
 with absolute /nix/store paths preserved. It also includes relocatable
-bin/ shims that allow running the bundled binaries on hosts without
-a local /nix/store.
+bin/ shims and a bundled static bwrap that allow running the bundled
+binaries on hosts without a local /nix/store or a host-provided bwrap.
 """,
     attrs = {
         "installable": attr.string(
@@ -113,6 +89,17 @@ a local /nix/store.
             default = Label("@nix_bootstrap//:nix_run_shim.sh"),
             allow_single_file = True,
         ),
+        "_bwrap": attr.label(
+            doc = "Internal statically-linked bwrap binary from bootstrap.",
+            default = Label("@nix_bootstrap//:bwrap"),
+            allow_single_file = True,
+            cfg = "exec",
+        ),
+        "_build_tpl": attr.label(
+            doc = "Template for the per-target package build script.",
+            default = Label("//:nix_package_build.sh.tpl"),
+            allow_single_file = True,
+        ),
     },
 )
 
@@ -120,15 +107,23 @@ def _nix_toolchain_impl(ctx):
     bundle = ctx.file.bundle
     out_dir = ctx.actions.declare_directory(ctx.label.name + "_extracted")
 
-    script = """
-    mkdir -p {out_dir}
-    tar -xzf {bundle} -C {out_dir}
-    """.format(bundle = bundle.path, out_dir = out_dir.path)
+    # The extract steps live in nix_extract.sh.tpl, materialized per target by
+    # expand_template (consistent with nix_package's build script).
+    extract_script = ctx.actions.declare_file(ctx.label.name + "_extract.sh")
+    ctx.actions.expand_template(
+        template = ctx.file._extract_tpl,
+        output = extract_script,
+        is_executable = True,
+        substitutions = {
+            "%{OUT_DIR}%": out_dir.path,
+            "%{BUNDLE}%": bundle.path,
+        },
+    )
 
     ctx.actions.run_shell(
-        inputs = [bundle],
+        inputs = [bundle, extract_script],
         outputs = [out_dir],
-        command = script,
+        command = extract_script.path,
         mnemonic = "ExtractNixBundle",
     )
 
@@ -146,6 +141,11 @@ Downstream rules can then invoke binaries from the extracted tree
             doc = "A nix_package output (.tar.gz) to extract.",
             mandatory = True,
             allow_single_file = [".tar.gz"],
+        ),
+        "_extract_tpl": attr.label(
+            doc = "Template for the per-target bundle extract script.",
+            default = Label("//:nix_extract.sh.tpl"),
+            allow_single_file = True,
         ),
     },
 )

--- a/nix_run_shim.sh
+++ b/nix_run_shim.sh
@@ -6,16 +6,17 @@
 # references, so they only run when that store content is present at
 # /nix/store. This shim re-execs the real store binary under bwrap with the
 # bundle's own store bound at /nix/store, making the bundle runnable on any
-# host with bubblewrap and unprivileged user namespaces -- no /nix on the host
-# required. The same file backs every executable in the bundle; the tool name
-# is taken from $0.
+# host with unprivileged user namespaces -- no /nix and no host bwrap required.
+# The bundle ships its own statically-linked bwrap at its root (copied in by
+# nix_package), execed here as "$HERE/bwrap". The same file backs every
+# executable in the bundle; the tool name is taken from $0.
 set -e
 
 HERE="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
 PKG="$(cat "$HERE/.nix_out")"
 TOOL="$(basename "$0")"
 
-exec bwrap \
+exec "$HERE/bwrap" \
     --bind "$HERE/nix/store" /nix/store \
     --proc /proc \
     --dev /dev \

--- a/nix_wrapper.sh.tpl
+++ b/nix_wrapper.sh.tpl
@@ -10,7 +10,15 @@
 set -e
 
 REPO_ROOT=$(cd "$(dirname "$0")" && pwd)
-BWRAP=$(command -v bwrap)
+# Use the pinned static bwrap materialized alongside this wrapper by
+# nix_bootstrap, not a host-provided one (hermeticity). It is staged next to
+# this script both in the bootstrap repo and in any action that lists it as an
+# input.
+BWRAP="$REPO_ROOT/bwrap"
+if [ ! -x "$BWRAP" ]; then
+    echo "nix_wrapper: bundled bwrap not found at $BWRAP" >&2
+    exit 1
+fi
 
 # The release unpacks to nix-<version>-x86_64-linux/. Discover it (and the nix
 # binaries within) version-agnostically so bumping the pinned release needs no


### PR DESCRIPTION
## Summary

Bring `bwrap` (bubblewrap) into the build hermetically instead of relying on a
host-provided one. `bwrap` is required to *run* the bootstrap Nix (it binds the
bundled store at `/nix/store`), so it cannot come from Nix itself — it must be a
standalone binary independent of `/nix/store`. `nix_bootstrap` now fetches a
pinned, statically-linked `bwrap` (musl, sha256-pinned) alongside the Nix
release, and every sandbox entry point execs that bundled binary rather than
resolving `bwrap` from `PATH`.

The only remaining host requirement is permission to create unprivileged user
namespaces.

## Commits

- **feat: bundle hermetic static bwrap instead of host-provided one**
  - `nix_bootstrap` downloads a pinned static `bwrap` 0.11.0
    (`VHSgunzo/bubblewrap-static` v0.11.0.2, sha256-pinned) and exports it.
  - `nix_wrapper.sh` runs nix under `"$REPO_ROOT/bwrap"`.
  - `nix_run_shim.sh` and `nix_cc_wrapper.sh.tpl` exec `"$HERE/bwrap"`.
  - `nix_package` copies `bwrap` into each relocatable bundle; `nix_cc_repo`
    copies it into the generated toolchain repo.
  - Extracted the two inline shell scripts in `nix_rules.bzl` into real template
    files (`nix_package_build.sh.tpl`, `nix_extract.sh.tpl`) materialized via
    `expand_template`, matching the project's convention of keeping shell as
    lintable, escaping-free files.
  - README/docs updated; stardoc regenerated.

## Testing

- `bazel build //:offline_build_test` — passes (Starlark + rule analysis +
  stardoc).
- `bazel build //:test_nix_version` — `nix (Nix) 2.24.10`, run inside the
  bundled static bwrap (no host bwrap involved).
- `bazel build //:run_hello` — `Hello, world!`, full pipeline end-to-end
  (`nix_package` → `nix_toolchain` → run-shim execing `$HERE/bwrap`).

Note: the `nix_cc` integration (`with-nix-clang`) was validated by analysis; its
bundled-bwrap mechanism is identical to the runtime-verified `run_hello` path.

This pull request has been created by an automated coding assistant, with
human supervision.

## Prompt

"use git workrees to work on features, with ../ as the base dir for the feature,
and each feature becomes a pr. now, for a new PR, figure out a way to bring bwrap
hermetically into the build instead of using the host-provided one"

Follow-up: "extract file content text into template files"
