### PR TITLE
ci: remove publish-bcr from tag and release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -69,8 +69,4 @@ jobs:
   secrets:
    BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
 
- publish-bcr:
-  needs: tag
-  uses: ./.github/workflows/publish-bcr.yml
-  with:
-   tag_name: ${{ needs.tag.outputs.tag_name }}
+


### PR DESCRIPTION
Summary:
- Removes the automatic publication to the Bazel Central Registry from the GitHub tag-and-release workflow.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
use git worktrees for new features, use ../ as base dir for worktrees; in a new worktree, remove publish-bcr step from the "tag and release" github workfloow. Only publishing to my registry shoudl be automatic