### PR TITLE
ci: fix bwrap permission denied in tag-and-release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -21,6 +21,12 @@ jobs:
      repository-cache: true
   - name: Checkout
     uses: actions/checkout@v4
+  - name: Install dependencies
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y bubblewrap
+      # Ubuntu 24.04 restricts unprivileged user namespaces.
+      sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
   - name: "Test"
     run: "bazel test --test_output=errors //..."
   - name: "Build integration (partially-installed)"


### PR DESCRIPTION
Summary of commits between origin/main and the top of the branch:
6385b9d ci: fix bwrap permission denied in tag-and-release workflow
1ffa8dd feat: implement elf_bundle rule and runfiles support

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: great, now fix https://github.com/filmil/bazel_local_nix/actions/runs/26548915668/job/78206734492 in a new worktree, and new pr
